### PR TITLE
chore: 🧹 依存関係の更新と不要なパッケージの削除

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,6 @@ dependencies = [
     "opencv-python>=4.11.0.86",
     "timm>=1.0.14",
     "lmdb>=1.6.2",
-    "pytorch-lightning>=2.5.0.post0",
-    "ultralytics>=8.3.73",
     "hydra-core>=1.3.2",
     "wandb>=0.19.6",
     "accelerate>=1.3.0",
@@ -35,6 +33,7 @@ dev-dependencies = [
     "matplotlib>=3.10.0",
     "japanize-matplotlib>=1.1.3",
     "ipykernel>=6.29.5",
+    "ruff==0.9.10",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
- pyproject.tomlから不要な依存パッケージを削除
  - pytorch-lightning
  - ultralytics

- 開発依存関係にruffを追加（バージョン0.9.10）