### PR TITLE
V2.0 lightning

### DIFF
--- a/src/configs/data/character_detection.yaml
+++ b/src/configs/data/character_detection.yaml
@@ -1,4 +1,4 @@
-path: data/yolo_dataset_character_detection_multi_grid  # データセットのルートディレクトリ
+path: datasets/yolo_dataset_character_detection_quadrant  # データセットのルートディレクトリ
 train: train/images  # 訓練画像のディレクトリ
 val: val/images      # 検証画像のディレクトリ
 test: test/images    # テスト画像のディレクトリ

--- a/src/configs/model/character_detection.yaml
+++ b/src/configs/model/character_detection.yaml
@@ -37,8 +37,6 @@ data:
   train_image_dir: "datasets/yolo_dataset_character_detection_quadrant/train/images/"
   val_image_dir: "datasets/yolo_dataset_character_detection_quadrant/val/images/"
   test_image_dir: "datasets/yolo_dataset_character_detection_quadrant/test/images/"
-  # Unicode dictionary for Kuzushiji characters
-  unicode_dict: "datasets/yolo_dataset_character_detection_quadrant/unicode_to_id.json"
 
 evaluation:
   iou_threshold: 0.5 # IoU threshold for mAP and accuracy calculation

--- a/src/configs/model/character_detection.yaml
+++ b/src/configs/model/character_detection.yaml
@@ -30,15 +30,15 @@ augmentation:
 
 data:
   # Paths to annotation files
-  train_annotation: "data/yolo_dataset_character_detection_multi_grid/train/train_column_info.csv"
-  val_annotation: "data/yolo_dataset_character_detection_multi_grid/val/val_column_info.csv"
-  test_annotation: "data/yolo_dataset_character_detection_multi_grid/test/test_column_info.csv"
+  train_annotation: "datasets/yolo_dataset_character_detection_quadrant/train/train_column_info.csv"
+  val_annotation: "datasets/yolo_dataset_character_detection_quadrant/val/val_column_info.csv"
+  test_annotation: "datasets/yolo_dataset_character_detection_quadrant/test/test_column_info.csv"
   # Paths to image directories
-  train_image_dir: "data/yolo_dataset_character_detection_multi_grid/train/images/"
-  val_image_dir: "data/yolo_dataset_character_detection_multi_grid/val/images/"
-  test_image_dir: "data/yolo_dataset_character_detection_multi_grid/test/images/"
+  train_image_dir: "datasets/yolo_dataset_character_detection_quadrant/train/images/"
+  val_image_dir: "datasets/yolo_dataset_character_detection_quadrant/val/images/"
+  test_image_dir: "datasets/yolo_dataset_character_detection_quadrant/test/images/"
   # Unicode dictionary for Kuzushiji characters
-  unicode_dict: "data/yolo_dataset_character_detection_multi_grid/unicode_to_id.json"
+  unicode_dict: "datasets/yolo_dataset_character_detection_quadrant/unicode_to_id.json"
 
 evaluation:
   iou_threshold: 0.5 # IoU threshold for mAP and accuracy calculation


### PR DESCRIPTION
This pull request updates the dataset paths in the configuration files to point to a new dataset location, `yolo_dataset_character_detection_quadrant`, instead of the previous `multi_grid` dataset. This ensures that both the data loading and model configuration reference the correct files and directories for training, validation, and testing.

**Dataset path updates:**

* Changed the dataset root path in `character_detection.yaml` from `data/yolo_dataset_character_detection_multi_grid` to `datasets/yolo_dataset_character_detection_quadrant`.
* Updated all annotation and image directory paths in `model/character_detection.yaml` to use the new `datasets/yolo_dataset_character_detection_quadrant` location for train, validation, and test splits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates configs to the new quadrant-based dataset location.
> 
> - Updates dataset root in `configs/data/character_detection.yaml` to `datasets/yolo_dataset_character_detection_quadrant`
> - Repoints `data.train/val/test_annotation` and `data.train/val/test_image_dir` in `configs/model/character_detection.yaml` to `datasets/yolo_dataset_character_detection_quadrant`
> - Removes `data.unicode_dict` entry from the model config
> - No changes to model architecture or training hyperparameters
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8f7a8696d1a892fe1c20daefec9ddb8d91757d6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **保守**
  * キャラクター検出モデルのデータセット設定をクアドラント形式のデータセット構造に更新しました。
  * モデル設定から不要なUnicode辞書参照を削除しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->